### PR TITLE
Main-PPLX-Feature

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -7,7 +7,7 @@
 # - PPLX (Perplexity API key for chat functionality)
 # - CONVEX_DEPLOYMENT (Convex deployment ID - reserved)
 # - CONVEX_URL (Convex URL - reserved)
-# - GOOGLE_MAPS_API_KEY (Google Maps API key)
+# - GOOGLE_MAPS_API_KEY (Google Maps API key - NOT A SECRET, is in Amplify Environment Variables)
 #
 # These secrets are automatically injected as environment variables
 # during the build process via amplify.yml configuration.

--- a/Claude.md
+++ b/Claude.md
@@ -21,9 +21,9 @@
 
 ## Secrets & Environment Variables
 - `PPLX`: server-only Perplexity key (used in `app/api/chat/route.ts`).
-  - **Production**: Set as Secret in Amplify console (Hosting → Secrets)
+  - **Production**: Set as Secret in Amplify console (Hosting -> Secrets)
   - **Local dev**: Use `npx ampx sandbox secret set PPLX` or add to `.env.local`
-  - **Code**: Access via `secret("PPLX")` from `@aws-amplify/backend`
+  - **Code**: Resolve with `secret("PPLX")` from `@aws-amplify/backend`, ensure the value is a non-empty string, fall back to `process.env.PPLX` for local overrides, and return a descriptive 500 if the secret is missing or malformed before calling external APIs.
 - `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`: client map key (used in `MapView` and `InteractiveMap`).
 - Optional placeholders: `CONVEX_DEPLOYMENT`, `AMPLIFY_ENV`.
 
@@ -36,4 +36,5 @@ See `docs/AMPLIFY_SECRETS.md` for complete setup guide.
 - Save source files as UTF-8 without BOM (PowerShell: `Set-Content -Encoding UTF8`).
 - Run `pnpm run typecheck` and `pnpm run build` locally before pushing structural changes.
 - If automating edits, prefer here-strings and keep docs (`README.md`, `agents.md`, `Claude.md`) in sync.
+
 

--- a/agents.md
+++ b/agents.md
@@ -57,10 +57,12 @@ If a page has no unique components yet, leave the `components/` folder empty but
 - Prefer using your editor for edits; if scripting with PowerShell, use here-strings and `Set-Content -Encoding UTF8`.
 
 ## Assistant (Perplexity)
-- Server route: `app/api/chat/route.ts` (uses `process.env.PPLX`).
-- Client: `components/ChatbotFab.tsx` (mounted on RFI map).
+- Server route: `app/api/chat/route.ts`.
+  - Resolve the API key with `secret("PPLX")` from `@aws-amplify/backend`, validate it is a non-empty string, and fall back to `process.env.PPLX` for local overrides.
+  - Return clear 500 responses when the secret is missing or malformed before forwarding requests to Perplexity.
+- Client: `components/ChatbotFab.tsx` (mounted on RFI map) with enhanced debug output for failed chats.
 - Env keys:
-  - `PPLX` (server-only)
+  - `PPLX` (server-only secret)
   - `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` (client)
 - To test without the service, stub `/api/chat` to return a canned payload.
 
@@ -69,4 +71,5 @@ If a page has no unique components yet, leave the `components/` folder empty but
 - Add/update Zod schemas when introducing new content or env requirements.
 - Keep shared types in sync with schemas (prefer `z.infer`).
 - Update docs (`README.md`, `agents.md`, `Claude.md`) whenever architecture or conventions change.
+
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { secret } from "@aws-amplify/backend";
 
 /**
  * POST /api/chat
@@ -6,29 +7,60 @@ import { NextResponse } from "next/server";
  * Proxies chat requests to Perplexity AI API using the PPLX secret configured in AWS Amplify.
  * This route is designed for production deployment on AWS Amplify only.
  *
- * Required secret: PPLX (configured in Amplify Console: Hosting → Secrets)
+ * Required secret: PPLX (configured in Amplify Console: Hosting -> Secrets)
  */
+const pplxSecret = secret("PPLX");
+const MIN_PPLX_KEY_LENGTH = 10;
+
+type ApiKeyResolution =
+  | { status: "resolved"; apiKey: string; source: "secret" | "env" }
+  | { status: "invalid"; source: "secret" | "env"; length: number }
+  | { status: "missing" };
+
+const resolvePplxApiKey = (): ApiKeyResolution => {
+  const secretCandidate = (pplxSecret as unknown as string | undefined)?.trim();
+
+  if (secretCandidate) {
+    if (secretCandidate.length >= MIN_PPLX_KEY_LENGTH) {
+      return { status: "resolved", apiKey: secretCandidate, source: "secret" };
+    }
+    return { status: "invalid", source: "secret", length: secretCandidate.length };
+  }
+
+  const envCandidate = process.env.PPLX?.trim();
+
+  if (envCandidate) {
+    if (envCandidate.length >= MIN_PPLX_KEY_LENGTH) {
+      return { status: "resolved", apiKey: envCandidate, source: "env" };
+    }
+    return { status: "invalid", source: "env", length: envCandidate.length };
+  }
+
+  return { status: "missing" };
+};
+
 export async function POST(req: Request) {
   try {
-    // Runtime validation of required secret
-    const apiKey = process.env.PPLX;
+    const resolvedApiKey = resolvePplxApiKey();
 
-    if (!apiKey) {
-      console.error("PPLX API key not found in environment variables");
-      console.error("Ensure PPLX secret is configured in AWS Amplify Console: Hosting → Secrets");
+    if (resolvedApiKey.status === "missing") {
+      console.error("PPLX secret not resolved (secret(\"PPLX\") returned no value)");
+      console.error("Ensure PPLX is configured via Amplify Hosting -> Secrets or a local .env file");
       return NextResponse.json({
         error: "API configuration error",
-        message: "Chat service is not properly configured"
+        message: "Chat service is not properly configured (missing PPLX secret)"
       }, { status: 500 });
     }
 
-    if (apiKey.length < 10) {
-      console.error("PPLX API key appears to be invalid (too short)");
+    if (resolvedApiKey.status === "invalid") {
+      console.error(`PPLX secret resolved from ${resolvedApiKey.source} but length ${resolvedApiKey.length} is invalid`);
       return NextResponse.json({
         error: "API configuration error",
-        message: "Chat service configuration is invalid"
+        message: "Chat service configuration is invalid (PPLX secret is malformed)"
       }, { status: 500 });
     }
+
+    const { apiKey } = resolvedApiKey;
 
     // Parse request body
     const { messages } = await req.json() as {

--- a/components/ChatbotFab.tsx
+++ b/components/ChatbotFab.tsx
@@ -30,6 +30,28 @@ const formatDebugPayload = (payload: unknown): string => {
   }
 };
 
+type PerplexityChatCompletion = {
+  choices?: {
+    message?: {
+      content?: string;
+    };
+  }[];
+};
+
+const extractAssistantMessage = (payload: unknown): string | undefined => {
+  if (!payload || typeof payload !== "object") {
+    return undefined;
+  }
+
+  const { choices } = payload as PerplexityChatCompletion;
+  if (!Array.isArray(choices) || choices.length === 0) {
+    return undefined;
+  }
+
+  const message = choices[0]?.message?.content;
+  return typeof message === "string" ? message : undefined;
+};
+
 export default function ChatbotFab() {
   const [open, setOpen] = useState(false);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -97,10 +119,7 @@ ${debugDetails}`
         return;
       }
 
-      const assistantContent =
-        typeof parsedBody === "object" && parsedBody !== null
-          ? (parsedBody as any)?.choices?.[0]?.message?.content
-          : undefined;
+      const assistantContent = extractAssistantMessage(parsedBody);
 
       if (typeof assistantContent !== "string" || !assistantContent.trim()) {
         const debugDetails = formatDebugPayload(parsedBody ?? rawBody);

--- a/components/ChatbotFab.tsx
+++ b/components/ChatbotFab.tsx
@@ -1,9 +1,34 @@
-﻿"use client";
+"use client";
 
 import { useState, useRef } from "react";
 import { MessageCircle, X, Send } from "lucide-react";
 
 export type ChatMessage = { role: "user" | "assistant"; content: string };
+
+const DEBUG_OUTPUT_LIMIT = 800;
+
+const formatDebugPayload = (payload: unknown): string => {
+  if (payload === null || payload === undefined) {
+    return "No response body received.";
+  }
+
+  if (typeof payload === "string") {
+    if (payload.length > DEBUG_OUTPUT_LIMIT) {
+      return `${payload.slice(0, DEBUG_OUTPUT_LIMIT)}... (truncated)`;
+    }
+    return payload;
+  }
+
+  try {
+    const serialized = JSON.stringify(payload, null, 2);
+    if (serialized.length > DEBUG_OUTPUT_LIMIT) {
+      return `${serialized.slice(0, DEBUG_OUTPUT_LIMIT)}... (truncated)`;
+    }
+    return serialized;
+  } catch {
+    return "Unable to serialize response payload for debugging.";
+  }
+};
 
 export default function ChatbotFab() {
   const [open, setOpen] = useState(false);
@@ -12,25 +37,86 @@ export default function ChatbotFab() {
   const [loading, setLoading] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
 
+  const scrollToBottom = () => {
+    if (!listRef.current) return;
+    listRef.current.scrollTo({
+      top: listRef.current.scrollHeight,
+      behavior: "smooth"
+    });
+  };
+
+  const appendAssistantMessage = (content: string) => {
+    setMessages((prev) => [...prev, { role: "assistant", content }]);
+    setTimeout(scrollToBottom, 0);
+  };
+
   const send = async () => {
     const text = input.trim();
     if (!text || loading) return;
-    const nextMsgs = [...messages, { role: "user", content: text } as ChatMessage];
+
+    const userMessage: ChatMessage = { role: "user", content: text };
+    const nextMsgs = [...messages, userMessage];
     setMessages(nextMsgs);
     setInput("");
     setLoading(true);
+
     try {
       const resp = await fetch("/api/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ messages: [{ role: "system", content: "You are an assistant for the Puerto Rico RFI Map. Be concise and helpful." }, ...nextMsgs] })
+        body: JSON.stringify({
+          messages: [
+            {
+              role: "system",
+              content:
+                "You are an assistant for the Puerto Rico RFI Map. Be concise and helpful."
+            },
+            ...nextMsgs
+          ]
+        })
       });
-      const data = await resp.json();
-      const content = data?.choices?.[0]?.message?.content ?? "Sorry, I couldn't find an answer.";
-      setMessages((m) => [...m, { role: "assistant", content }]);
-      listRef.current?.scrollTo({ top: 999999, behavior: "smooth" });
-    } catch { 
-      setMessages((m) => [...m, { role: "assistant", content: "There was an error contacting the assistant." }]);
+
+      const rawBody = await resp.text();
+      let parsedBody: unknown = null;
+
+      if (rawBody) {
+        try {
+          parsedBody = JSON.parse(rawBody);
+        } catch {
+          parsedBody = rawBody;
+        }
+      }
+
+      if (!resp.ok) {
+        const debugDetails = formatDebugPayload(parsedBody ?? rawBody);
+        appendAssistantMessage(
+          `Chat service responded with ${resp.status} ${resp.statusText}.
+
+${debugDetails}`
+        );
+        return;
+      }
+
+      const assistantContent =
+        typeof parsedBody === "object" && parsedBody !== null
+          ? (parsedBody as any)?.choices?.[0]?.message?.content
+          : undefined;
+
+      if (typeof assistantContent !== "string" || !assistantContent.trim()) {
+        const debugDetails = formatDebugPayload(parsedBody ?? rawBody);
+        appendAssistantMessage(
+          `Chat service returned no assistant message.
+
+${debugDetails}`
+        );
+        return;
+      }
+
+      appendAssistantMessage(assistantContent.trim());
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : String(error ?? "Unknown error");
+      appendAssistantMessage(`Chat request failed: ${message}`);
     } finally {
       setLoading(false);
     }
@@ -79,7 +165,7 @@ export default function ChatbotFab() {
                     </span>
                   </li>
                 ))}
-                {loading && <li className="text-left text-[#6f705f]">Thinking…</li>}
+                {loading && <li className="text-left text-[#6f705f]">Thinking.</li>}
               </ul>
             )}
           </div>
@@ -89,7 +175,7 @@ export default function ChatbotFab() {
               value={input}
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && send()}
-              placeholder="Type your question…"
+              placeholder="Type your question."
               className="flex-1 rounded-md border border-[#d7d1c3] bg-white px-3 py-2 text-sm text-[#1b1c16] placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-[#4b5a2a]"
             />
             <button
@@ -106,4 +192,3 @@ export default function ChatbotFab() {
     </>
   );
 }
-

--- a/convex/_generated/api.js
+++ b/convex/_generated/api.js
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 /**
  * Generated `api` utility.
  *

--- a/convex/_generated/dataModel.d.ts
+++ b/convex/_generated/dataModel.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 /**
  * Generated data model types.
  *

--- a/convex/_generated/server.d.ts
+++ b/convex/_generated/server.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 /**
  * Generated utilities for implementing server-side Convex query and mutation functions.
  *

--- a/convex/_generated/server.js
+++ b/convex/_generated/server.js
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 /**
  * Generated utilities for implementing server-side Convex query and mutation functions.
  *


### PR DESCRIPTION
docs/AMPLIFY_SECRETS.md now includes a concrete server-route pattern for Amplify secrets: resolve with secret("<KEY>"), verify the string, fall back to process.env, and emit explicit 500s when configuration is wrong.
Claude.md notes the same guidelines under Secrets & Environment Variables so any Claude session follows the hardened flow.
agents.md mirrors the procedure in the Assistant section, making clear how /api/chat should handle PPLX going forward.